### PR TITLE
Add messaging persistence and notifications

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const authRoutes = require('./routes/auth');
 const listingRoutes = require('./routes/listings');
 const userRoutes = require('./routes/users');
+const messageRoutes = require('./routes/messages');
 
 const app = express();
 
@@ -22,6 +23,7 @@ app.get('/api/health', (req, res) => {
 app.use('/api/auth', authRoutes);
 app.use('/api/listings', listingRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/messages', messageRoutes);
 
 const clientDir = path.resolve(__dirname, '..', '..', 'client');
 if (process.env.SERVE_CLIENT !== 'false' && fs.existsSync(clientDir)) {

--- a/server/src/models/EmailLog.js
+++ b/server/src/models/EmailLog.js
@@ -3,8 +3,9 @@ const { Schema, model, Types } = require('mongoose');
 const emailLogSchema = new Schema(
   {
     user: { type: Types.ObjectId, ref: 'User', required: true },
-    listing: { type: Types.ObjectId, ref: 'Listing', required: true },
-    searchName: { type: String, required: true },
+    listing: { type: Types.ObjectId, ref: 'Listing' },
+    message: { type: Types.ObjectId, ref: 'Message' },
+    searchName: { type: String },
     to: { type: String, required: true },
     subject: { type: String, required: true },
     body: { type: String, required: true },

--- a/server/src/models/Message.js
+++ b/server/src/models/Message.js
@@ -1,0 +1,13 @@
+const { Schema, model, Types } = require('mongoose');
+
+const messageSchema = new Schema(
+  {
+    sender: { type: Types.ObjectId, ref: 'User', required: true },
+    recipient: { type: Types.ObjectId, ref: 'User', required: true },
+    listing: { type: Types.ObjectId, ref: 'Listing' },
+    body: { type: String, required: true, trim: true }
+  },
+  { timestamps: true }
+);
+
+module.exports = model('Message', messageSchema);

--- a/server/src/routes/messages.js
+++ b/server/src/routes/messages.js
@@ -1,0 +1,111 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Message = require('../models/Message');
+const User = require('../models/User');
+const Listing = require('../models/Listing');
+const { authenticate } = require('../middleware/auth');
+const { sendMessageNotificationEmail } = require('../services/emailService');
+
+const router = express.Router();
+
+function formatMessage(message) {
+  if (!message) {
+    return null;
+  }
+
+  const formatted = message.toObject({ virtuals: true });
+  delete formatted.__v;
+  return formatted;
+}
+
+router.post('/', authenticate, async (req, res, next) => {
+  try {
+    const { recipientId, listingId, body } = req.body || {};
+
+    if (!recipientId || !mongoose.Types.ObjectId.isValid(recipientId)) {
+      return res.status(400).json({ message: 'A valid recipientId is required.' });
+    }
+
+    const trimmedBody = typeof body === 'string' ? body.trim() : '';
+    if (!trimmedBody) {
+      return res.status(400).json({ message: 'Message body is required.' });
+    }
+
+    const recipient = await User.findById(recipientId);
+    if (!recipient) {
+      return res.status(404).json({ message: 'Recipient not found.' });
+    }
+
+    let listing = null;
+    if (listingId) {
+      if (!mongoose.Types.ObjectId.isValid(listingId)) {
+        return res.status(400).json({ message: 'Invalid listingId provided.' });
+      }
+
+      listing = await Listing.findById(listingId).populate('agent', 'fullName email role company phoneNumber');
+      if (!listing) {
+        return res.status(404).json({ message: 'Listing not found.' });
+      }
+
+      const listingAgentId = listing.agent?._id?.toString();
+      if (
+        listingAgentId &&
+        listingAgentId !== req.user._id.toString() &&
+        listingAgentId !== recipient._id.toString()
+      ) {
+        return res
+          .status(400)
+          .json({ message: 'Messages tied to a listing must include the listing agent as sender or recipient.' });
+      }
+    }
+
+    const message = new Message({
+      sender: req.user._id,
+      recipient: recipient._id,
+      listing: listing ? listing._id : undefined,
+      body: trimmedBody
+    });
+
+    await message.save();
+
+    const populated = await message.populate([
+      { path: 'sender', select: 'fullName email role company phoneNumber' },
+      { path: 'recipient', select: 'fullName email role company phoneNumber' },
+      {
+        path: 'listing',
+        select: 'title area address agent',
+        populate: { path: 'agent', select: 'fullName email role company phoneNumber' }
+      }
+    ]);
+
+    let agentUser = null;
+    let buyerUser = null;
+
+    if (listing && listing.agent) {
+      agentUser = listing.agent;
+      if (listing.agent._id.toString() === populated.sender._id.toString()) {
+        buyerUser = populated.recipient;
+      } else if (listing.agent._id.toString() === populated.recipient._id.toString()) {
+        buyerUser = populated.sender;
+      }
+    } else {
+      agentUser = [populated.sender, populated.recipient].find((user) => user && user.role === 'agent') || null;
+      buyerUser = [populated.sender, populated.recipient].find((user) => user && user.role !== 'agent') || null;
+    }
+
+    await sendMessageNotificationEmail({
+      message: populated,
+      sender: populated.sender,
+      recipient: populated.recipient,
+      listing: listing || populated.listing,
+      agent: agentUser,
+      buyer: buyerUser
+    });
+
+    res.status(201).json(formatMessage(populated));
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/server/src/test/messages.test.js
+++ b/server/src/test/messages.test.js
@@ -1,0 +1,108 @@
+jest.mock('nodemailer', () => {
+  const sendMailMock = jest.fn().mockResolvedValue({ messageId: 'message-transport' });
+  const createTransportMock = jest.fn(() => ({ sendMail: sendMailMock }));
+  return {
+    createTransport: createTransportMock,
+    __mock: { sendMailMock, createTransportMock }
+  };
+});
+
+const request = require('supertest');
+const nodemailer = require('nodemailer');
+const app = require('../app');
+const Message = require('../models/Message');
+const EmailLog = require('../models/EmailLog');
+
+const { sendMailMock } = nodemailer.__mock;
+
+async function registerUser(overrides = {}) {
+  const payload = {
+    fullName: 'Test User',
+    email: `user-${Math.random().toString(16).slice(2)}@example.com`,
+    password: 'Password123!',
+    role: 'user',
+    ...overrides
+  };
+
+  const response = await request(app).post('/api/auth/register').send(payload);
+  return response;
+}
+
+describe('Messaging API', () => {
+  beforeEach(() => {
+    sendMailMock.mockClear();
+  });
+
+  it('stores messages and records email notifications', async () => {
+    const agentRes = await registerUser({
+      fullName: 'Agent Smith',
+      email: 'agent-message@example.com',
+      role: 'agent'
+    });
+    expect(agentRes.status).toBe(201);
+    const agentToken = agentRes.body.token;
+    const agentId = agentRes.body.user._id;
+
+    const buyerRes = await registerUser({
+      fullName: 'Buyer Jane',
+      email: 'buyer-message@example.com',
+      role: 'user'
+    });
+    expect(buyerRes.status).toBe(201);
+    const buyerToken = buyerRes.body.token;
+    const buyerId = buyerRes.body.user._id;
+
+    const listingPayload = {
+      title: 'Riverfront Loft',
+      description: 'Spacious loft with skyline views.',
+      price: 450000,
+      bedrooms: 2,
+      bathrooms: 2,
+      area: 'Downtown',
+      address: {
+        street: '200 Main St',
+        city: 'Minneapolis',
+        state: 'MN',
+        postalCode: '55414'
+      }
+    };
+
+    const createListingRes = await request(app)
+      .post('/api/listings')
+      .set('Authorization', `Bearer ${agentToken}`)
+      .send(listingPayload);
+
+    expect(createListingRes.status).toBe(201);
+    const listingId = createListingRes.body._id;
+
+    const messageBody = 'Hello Agent, I would love to schedule a tour!';
+
+    const messageRes = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ recipientId: agentId, listingId, body: messageBody });
+
+    expect(messageRes.status).toBe(201);
+    expect(messageRes.body.body).toBe(messageBody);
+    expect(messageRes.body.sender._id).toBe(buyerId);
+    expect(messageRes.body.recipient._id).toBe(agentId);
+    expect(messageRes.body.listing._id).toBe(listingId);
+
+    const messages = await Message.find({});
+    expect(messages).toHaveLength(1);
+    expect(messages[0].body).toBe(messageBody);
+    expect(messages[0].listing.toString()).toBe(listingId);
+
+    const logs = await EmailLog.find({ message: messages[0]._id });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].to).toBe('agent-message@example.com');
+    expect(logs[0].user.toString()).toBe(agentId);
+    expect(logs[0].searchName).toMatch(/message/);
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    const sentEmail = sendMailMock.mock.calls[0][0];
+    expect(sentEmail.to).toBe('agent-message@example.com');
+    expect(sentEmail.subject).toMatch(/messaged you/i);
+    expect(sentEmail.text).toMatch(messageBody);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Message mongoose model to persist agent/buyer conversations with optional listing references
- expose a POST /api/messages endpoint that validates participants, stores the message, and triggers recipient notifications
- extend the email service with a message notification helper and cover the flow with integration tests that assert logging

## Testing
- npm test *(fails: jest unavailable because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd779c0cc08327a07d567597b25ab1