### PR TITLE
Point Resend API key to Vercel integration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,10 @@
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/index.js" },
     { "source": "/(.*)", "destination": "/client/$1" }
-  ]
+  ],
+  "env": {
+    "RESEND_API_KEY": "@resend",
+    "EMAIL_FROM": "hello@lgweb.app",
+    "RESEND_DOMAIN": "lgweb.app"
+  }
 }


### PR DESCRIPTION
## Summary
- update the Vercel env configuration so RESEND_API_KEY uses the managed Resend integration secret instead of a deleted raw key

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd7921ce008327b5b9e4cecbc7c629